### PR TITLE
Add missing package.json

### DIFF
--- a/TicketingSystem.CLI/package.json
+++ b/TicketingSystem.CLI/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "ticketingsystem-cli",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.14.2",
+    "axios": "^1.5.0"
+  },
+  "devDependencies": {
+    "vite": "^4.0.0",
+    "typescript": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "tailwindcss": "^3.0.0",
+    "autoprefixer": "^10.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add `TicketingSystem.CLI/package.json` so npm dependencies can be installed

## Testing
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688af6dd16b08331abe4efa4ada39376