### PR TITLE
Add scoped service registrations

### DIFF
--- a/TicketingSystem.API/Program.cs
+++ b/TicketingSystem.API/Program.cs
@@ -9,6 +9,9 @@ builder.Services.AddControllers();
 builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
 
+builder.Services.AddScoped<IAuthService, AuthService>();
+builder.Services.AddScoped<ITicketService, TicketService>();
+
 var key = Encoding.ASCII.GetBytes(builder.Configuration["Jwt:Key"]);
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>


### PR DESCRIPTION
## Summary
- register AuthService and TicketService with scoped lifetime

## Testing
- `dotnet build TicketingSystem.sln` *(fails: type or namespace name 'DbSet<>' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_688b674666008331aad1d65043255bdc