### PR TITLE
Add User role and organization links

### DIFF
--- a/TicketingSystem.API/Controllers/AuthController.cs
+++ b/TicketingSystem.API/Controllers/AuthController.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Mvc;
+
 [ApiController]
 [Route("api/auth")]
 public class AuthController : ControllerBase

--- a/TicketingSystem.API/Controllers/TicketCommentsController.cs
+++ b/TicketingSystem.API/Controllers/TicketCommentsController.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
 
 [ApiController]
 [Route("api/comments")]

--- a/TicketingSystem.API/Controllers/TicketsController.cs
+++ b/TicketingSystem.API/Controllers/TicketsController.cs
@@ -1,3 +1,6 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
 [ApiController]
 [Route("api/tickets")]
 [Authorize]

--- a/TicketingSystem.API/Models/User.cs
+++ b/TicketingSystem.API/Models/User.cs
@@ -1,1 +1,10 @@
-public class User { public int Id { get; set; } public string Email { get; set; } = string.Empty; public string PasswordHash { get; set; } = string.Empty; }
+public class User
+{
+    public int Id { get; set; }
+    public string Email { get; set; } = string.Empty;
+    public string PasswordHash { get; set; } = string.Empty;
+    public string Role { get; set; } = string.Empty;
+
+    public int OrganizationId { get; set; }
+    public Organization Organization { get; set; }
+}

--- a/TicketingSystem.API/Services/AuthService.cs
+++ b/TicketingSystem.API/Services/AuthService.cs
@@ -1,3 +1,9 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+
 public class AuthService : IAuthService
 {
     private readonly AppDbContext _context;

--- a/TicketingSystem.API/Services/ITicketService.cs
+++ b/TicketingSystem.API/Services/ITicketService.cs
@@ -1,3 +1,5 @@
+using System.Security.Claims;
+
 public interface ITicketService
 {
     Task<IEnumerable<object>> GetTicketsAsync(ClaimsPrincipal user);

--- a/TicketingSystem.API/Services/TicketService.cs
+++ b/TicketingSystem.API/Services/TicketService.cs
@@ -1,3 +1,6 @@
+using System.Security.Claims;
+using Microsoft.EntityFrameworkCore;
+
 public class TicketService : ITicketService
 {
     private readonly AppDbContext _context;

--- a/TicketingSystem.API/TicketingSystem.API.csproj
+++ b/TicketingSystem.API/TicketingSystem.API.csproj
@@ -6,4 +6,11 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.4" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- expand the `User` model with role and organization fields
- add required EF Core, JWT and BCrypt packages
- include missing `using` directives for controllers and services

## Testing
- `dotnet restore TicketingSystem.API/TicketingSystem.API.csproj`
- `dotnet build TicketingSystem.API/TicketingSystem.API.csproj --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_688b6746409483319bfec447d39d500b