### PR TITLE
Validate claims before use

### DIFF
--- a/TicketingSystem.API/Controllers/TicketCommentsController.cs
+++ b/TicketingSystem.API/Controllers/TicketCommentsController.cs
@@ -35,7 +35,9 @@ public class TicketCommentsController : ControllerBase
     [HttpPost("{ticketId}")]
     public async Task<IActionResult> AddComment(int ticketId, [FromBody] string message)
     {
-        var userId = int.Parse(User.FindFirst(ClaimTypes.NameIdentifier).Value);
+        var claim = User.FindFirst(ClaimTypes.NameIdentifier);
+        if (claim == null) return Unauthorized();
+        var userId = int.Parse(claim.Value);
         var comment = new Comment
         {
             Message = message,

--- a/TicketingSystem.API/Middleware/ErrorHandlerMiddleware.cs
+++ b/TicketingSystem.API/Middleware/ErrorHandlerMiddleware.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Http;
+
 public class ErrorHandlerMiddleware
 {
     private readonly RequestDelegate _next;
@@ -12,6 +14,12 @@ public class ErrorHandlerMiddleware
         try
         {
             await _next(context);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            context.Response.ContentType = "application/json";
+            await context.Response.WriteAsync($"{{ \"error\": \"{ex.Message}\" }}");
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- guard claim lookups for OrgId and user ID in ticket service
- return 401 when comment creation lacks user claim
- map `UnauthorizedAccessException` to HTTP 401

## Testing
- `dotnet build` *(fails: 'User' does not contain a definition for 'Organization')*

------
https://chatgpt.com/codex/tasks/task_e_688d8b5d49d88331bec14bfd5cbf0c8e