### PR TITLE
Add IIS web.config for API deployment

### DIFF
--- a/TicketingSystem.API/TicketingSystem.API.csproj
+++ b/TicketingSystem.API/TicketingSystem.API.csproj
@@ -14,4 +14,9 @@
 
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Update="web.config" CopyToPublishDirectory="Always" />
+    <Content Update="logs/placeholder.txt" CopyToPublishDirectory="Always" />
+  </ItemGroup>
+
 </Project>

--- a/TicketingSystem.API/web.config
+++ b/TicketingSystem.API/web.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
+    </handlers>
+    <aspNetCore processPath="dotnet" arguments="TicketingSystem.API.dll" stdoutLogEnabled="true" stdoutLogFile="logs/stdout" hostingModel="InProcess" />
+  </system.webServer>
+</configuration>


### PR DESCRIPTION
## Summary
- add ASP.NET Core web.config to host TicketingSystem.API.dll in IIS and route logging to `logs` directory
- publish `web.config` and `logs` directory via project file so they arrive in the publish output

## Testing
- `dotnet test`
- `dotnet publish TicketingSystem.API/TicketingSystem.API.csproj -c Release -o publish`


------
https://chatgpt.com/codex/tasks/task_e_688d9f0e5a988331b8c5cf179c402e0f