### PR TITLE
Enable configurable DB connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ dotnet ef database update
 dotnet run
 ```
 
+#### Configuration
+The API requires a SQL Server connection string. During development it reads from `appsettings.json`.
+For production deployments, set an environment variable named `ConnectionStrings__DefaultConnection` (or `DefaultConnection`) to supply the connection string at runtime.
+
 ### Frontend (Client)
 ```bash
 cd TicketingSystem.CLI

--- a/TicketingSystem.API/Program.cs
+++ b/TicketingSystem.API/Program.cs
@@ -6,8 +6,16 @@ using System.Text;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
+var defaultConnection = builder.Configuration.GetConnectionString("DefaultConnection")
+                        ?? Environment.GetEnvironmentVariable("DefaultConnection");
+
+if (string.IsNullOrWhiteSpace(defaultConnection))
+{
+    throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
+}
+
 builder.Services.AddDbContext<AppDbContext>(options =>
-    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+    options.UseSqlServer(defaultConnection));
 
 builder.Services.AddScoped<IAuthService, AuthService>();
 builder.Services.AddScoped<ITicketService, TicketService>();

--- a/TicketingSystem.API/TicketingSystem.API.csproj
+++ b/TicketingSystem.API/TicketingSystem.API.csproj
@@ -7,14 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.2" />
-
   </ItemGroup>
 
   <ItemGroup>
+    <Content Update="appsettings.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="Always" />
     <Content Update="web.config" CopyToPublishDirectory="Always" />
     <Content Update="logs/placeholder.txt" CopyToPublishDirectory="Always" />
   </ItemGroup>

--- a/TicketingSystem.API/appsettings.json
+++ b/TicketingSystem.API/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=TicketingSystem;Trusted_Connection=True;"
+  }
+}


### PR DESCRIPTION
## Summary
- add API appsettings.json with default connection string placeholder
- load connection string from configuration or `DefaultConnection` environment variable
- copy appsettings.json to publish output and document required env vars

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_688daba9c22c833193c5cba31280c23e