### PR TITLE
Restrict ticket foreign key deletes

### DIFF
--- a/TicketingSystem.API/Data/AppDbContext.cs
+++ b/TicketingSystem.API/Data/AppDbContext.cs
@@ -13,9 +13,16 @@ public class AppDbContext : DbContext
     {
         base.OnModelCreating(modelBuilder);
 
-        modelBuilder.Entity<User>()
-            .HasOne(u => u.Organization)
+        modelBuilder.Entity<Ticket>()
+            .HasOne(t => t.CreatedBy)
             .WithMany()
-            .HasForeignKey(u => u.OrganizationId);
+            .HasForeignKey(t => t.CreatedById)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        modelBuilder.Entity<Ticket>()
+            .HasOne(t => t.AssignedTo)
+            .WithMany()
+            .HasForeignKey(t => t.AssignedToId)
+            .OnDelete(DeleteBehavior.Restrict);
     }
 }


### PR DESCRIPTION
## Summary
- replace AppDbContext OnModelCreating with relationships for Ticket.CreatedBy and Ticket.AssignedTo using DeleteBehavior.Restrict

## Testing
- `dotnet build TicketingSystem.sln`


------
https://chatgpt.com/codex/tasks/task_e_688db4edd6448331897b96336532c931