### PR TITLE
Add migration to restrict ticket user deletes

### DIFF
--- a/TicketingSystem.API/Migrations/20250802071050_RestrictTicketUserDeletes.Designer.cs
+++ b/TicketingSystem.API/Migrations/20250802071050_RestrictTicketUserDeletes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace TicketingSystem.API.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250802071050_RestrictTicketUserDeletes")]
+    partial class RestrictTicketUserDeletes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TicketingSystem.API/Migrations/20250802071050_RestrictTicketUserDeletes.cs
+++ b/TicketingSystem.API/Migrations/20250802071050_RestrictTicketUserDeletes.cs
@@ -1,0 +1,65 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TicketingSystem.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class RestrictTicketUserDeletes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Tickets_Users_AssignedToId",
+                table: "Tickets");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Tickets_Users_CreatedById",
+                table: "Tickets");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Tickets_Users_AssignedToId",
+                table: "Tickets",
+                column: "AssignedToId",
+                principalTable: "Users",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Tickets_Users_CreatedById",
+                table: "Tickets",
+                column: "CreatedById",
+                principalTable: "Users",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Tickets_Users_AssignedToId",
+                table: "Tickets");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Tickets_Users_CreatedById",
+                table: "Tickets");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Tickets_Users_AssignedToId",
+                table: "Tickets",
+                column: "AssignedToId",
+                principalTable: "Users",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Tickets_Users_CreatedById",
+                table: "Tickets",
+                column: "CreatedById",
+                principalTable: "Users",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- enforce restrictive delete behavior for ticket `CreatedBy` and `AssignedTo` relationships
- update model snapshot reflecting cascade deletes for `Organization`

## Testing
- `dotnet ef migrations add RestrictTicketUserDeletes`
- `dotnet ef database update` *(fails: Could not open a connection to SQL Server)*

------
https://chatgpt.com/codex/tasks/task_e_688db9511bac8331942fc85909dfdd0f