### PR TITLE
Restrict comment user delete cascade

### DIFF
--- a/TicketingSystem.API/Data/AppDbContext.cs
+++ b/TicketingSystem.API/Data/AppDbContext.cs
@@ -30,5 +30,11 @@ public class AppDbContext : DbContext
             .WithMany()
             .HasForeignKey(t => t.OrganizationId)
             .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<Comment>()
+            .HasOne(c => c.User)
+            .WithMany()
+            .HasForeignKey(c => c.UserId)
+            .OnDelete(DeleteBehavior.Restrict);
     }
 }

--- a/TicketingSystem.API/Migrations/20250802075224_InitialCreate.Designer.cs
+++ b/TicketingSystem.API/Migrations/20250802075224_InitialCreate.Designer.cs
@@ -11,7 +11,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace TicketingSystem.API.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    [Migration("20250802072802_InitialCreate")]
+    [Migration("20250802075224_InitialCreate")]
     partial class InitialCreate
     {
         /// <inheritdoc />
@@ -156,7 +156,7 @@ namespace TicketingSystem.API.Migrations
                     b.HasOne("TicketingSystem.API.Models.User", "User")
                         .WithMany()
                         .HasForeignKey("UserId")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.Navigation("Ticket");

--- a/TicketingSystem.API/Migrations/20250802075224_InitialCreate.cs
+++ b/TicketingSystem.API/Migrations/20250802075224_InitialCreate.cs
@@ -108,7 +108,7 @@ namespace TicketingSystem.API.Migrations
                         column: x => x.UserId,
                         principalTable: "Users",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
+                        onDelete: ReferentialAction.Restrict);
                 });
 
             migrationBuilder.CreateIndex(

--- a/TicketingSystem.API/Migrations/AppDbContextModelSnapshot.cs
+++ b/TicketingSystem.API/Migrations/AppDbContextModelSnapshot.cs
@@ -153,7 +153,7 @@ namespace TicketingSystem.API.Migrations
                     b.HasOne("TicketingSystem.API.Models.User", "User")
                         .WithMany()
                         .HasForeignKey("UserId")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.Navigation("Ticket");
@@ -206,4 +206,3 @@ namespace TicketingSystem.API.Migrations
         }
     }
 }
-


### PR DESCRIPTION
## Summary
- configure Comment→User relationship to restrict delete cascade
- regenerate EF Core migrations

## Testing
- `dotnet ef migrations add InitialCreate`
- `dotnet ef database update` *(fails: A network-related or instance-specific error occurred while establishing a connection to SQL Server)*
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688dc3203edc833192df1333d2cbaa5e