### PR TITLE
Restrict user deletes on comments

### DIFF
--- a/TicketingSystem.API/Data/AppDbContext.cs
+++ b/TicketingSystem.API/Data/AppDbContext.cs
@@ -30,5 +30,11 @@ public class AppDbContext : DbContext
             .WithMany()
             .HasForeignKey(t => t.OrganizationId)
             .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<Comment>()
+            .HasOne(c => c.User)
+            .WithMany()
+            .HasForeignKey(c => c.UserId)
+            .OnDelete(DeleteBehavior.Restrict);
     }
 }

--- a/TicketingSystem.API/Migrations/20250802083744_RestrictCommentUserDeletes.Designer.cs
+++ b/TicketingSystem.API/Migrations/20250802083744_RestrictCommentUserDeletes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace TicketingSystem.API.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250802083744_RestrictCommentUserDeletes")]
+    partial class RestrictCommentUserDeletes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TicketingSystem.API/Migrations/20250802083744_RestrictCommentUserDeletes.cs
+++ b/TicketingSystem.API/Migrations/20250802083744_RestrictCommentUserDeletes.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TicketingSystem.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class RestrictCommentUserDeletes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Comments_Users_UserId",
+                table: "Comments");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Comments_Users_UserId",
+                table: "Comments",
+                column: "UserId",
+                principalTable: "Users",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Comments_Users_UserId",
+                table: "Comments");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Comments_Users_UserId",
+                table: "Comments",
+                column: "UserId",
+                principalTable: "Users",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Set Comment.User foreign key to restrict deletes
- Regenerate EF Core migration and snapshot for new restriction

## Testing
- `dotnet ef migrations add RestrictCommentUserDeletes --project TicketingSystem.API --startup-project TicketingSystem.API`
- `dotnet ef database update --project TicketingSystem.API --startup-project TicketingSystem.API` *(fails: Could not open a connection to SQL Server)*
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_688dcdcc697c8331bb21fc5affb8fdec