### PR TITLE
Include both env names for DB connection string

### DIFF
--- a/TicketingSystem.API/Program.cs
+++ b/TicketingSystem.API/Program.cs
@@ -8,6 +8,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllers();
 builder.Services.AddHealthChecks();
 var defaultConnection = builder.Configuration.GetConnectionString("DefaultConnection")
+                        ?? Environment.GetEnvironmentVariable("ConnectionStrings__DefaultConnection")
                         ?? Environment.GetEnvironmentVariable("DefaultConnection");
 
 if (string.IsNullOrWhiteSpace(defaultConnection))


### PR DESCRIPTION
## Summary
- allow API to read DB connection string from `ConnectionStrings__DefaultConnection`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_688ed4ec09b483258b21daf7f8944218