### PR TITLE
Add test for cross-org ticket assignment authorization

### DIFF
--- a/TicketingSystem.API.Tests/Services/TicketServiceTests.cs
+++ b/TicketingSystem.API.Tests/Services/TicketServiceTests.cs
@@ -1,0 +1,46 @@
+using System.Security.Claims;
+using Microsoft.EntityFrameworkCore;
+using TicketingSystem.API.Data;
+using TicketingSystem.API.Models;
+using TicketingSystem.API.Services;
+using Xunit;
+
+namespace TicketingSystem.API.Tests.Services;
+
+public class TicketServiceTests
+{
+    [Fact]
+    public async Task AssignTicketAsync_ThrowsForMismatchedOrg()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        using var context = new AppDbContext(options);
+
+        var org1 = new Organization { Id = 1, Name = "Org1" };
+        var org2 = new Organization { Id = 2, Name = "Org2" };
+        context.Organizations.AddRange(org1, org2);
+
+        var creator = new User { Id = 10, Email = "creator@org1", OrganizationId = org1.Id };
+        var otherUser = new User { Id = 20, Email = "user@org2", OrganizationId = org2.Id };
+        context.Users.AddRange(creator, otherUser);
+
+        var ticket = new Ticket { Id = 100, Title = "Test", OrganizationId = org1.Id, CreatedById = creator.Id };
+        context.Tickets.Add(ticket);
+
+        await context.SaveChangesAsync();
+
+        var service = new TicketService(context);
+
+        var claims = new List<Claim>
+        {
+            new Claim(ClaimTypes.NameIdentifier, otherUser.Id.ToString()),
+            new Claim("OrgId", otherUser.OrganizationId.ToString())
+        };
+        var user = new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"));
+
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(
+            () => service.AssignTicketAsync(ticket.Id, user));
+    }
+}

--- a/TicketingSystem.API.Tests/TicketingSystem.API.Tests.csproj
+++ b/TicketingSystem.API.Tests/TicketingSystem.API.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.6.6">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\TicketingSystem.API\TicketingSystem.API.csproj" />
+  </ItemGroup>
+</Project>

--- a/TicketingSystem.sln
+++ b/TicketingSystem.sln
@@ -6,6 +6,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TicketingSystem.API", "Tick
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TicketingSystem.CLI", "TicketingSystem.CLI\TicketingSystem.CLI.csproj", "{22222222-2222-2222-2222-222222222222}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TicketingSystem.API.Tests", "TicketingSystem.API.Tests\TicketingSystem.API.Tests.csproj", "{33333333-3333-3333-3333-333333333333}"
+EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
         Debug|Any CPU = Debug|Any CPU
@@ -20,5 +22,9 @@ Global
         {22222222-2222-2222-2222-222222222222}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {22222222-2222-2222-2222-222222222222}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {22222222-2222-2222-2222-222222222222}.Release|Any CPU.Build.0 = Release|Any CPU
+        {33333333-3333-3333-3333-333333333333}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {33333333-3333-3333-3333-333333333333}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {33333333-3333-3333-3333-333333333333}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {33333333-3333-3333-3333-333333333333}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- add new xUnit test project for API services
- verify AssignTicketAsync throws UnauthorizedAccessException when user from different org

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688ed4edb0108325a4aaae9762fc0bc4