### PR TITLE
Ensure controllers use standard API routing and usings

### DIFF
--- a/TicketingSystem.API/Controllers/AuthController.cs
+++ b/TicketingSystem.API/Controllers/AuthController.cs
@@ -1,6 +1,9 @@
 using Microsoft.AspNetCore.Identity.Data;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 
+[ApiController]
+[Route("api/[controller]")]
 public class AuthController(IAuthService authService) : ControllerBase
 {
     private readonly IAuthService _authService = authService;

--- a/TicketingSystem.API/Controllers/DepartmentsController.cs
+++ b/TicketingSystem.API/Controllers/DepartmentsController.cs
@@ -1,6 +1,8 @@
-using Microsoft.AspNetCore.Mvc; // Add this using directive
-using Microsoft.AspNetCore.Authorization; // <-- Add this using directive
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 
+[ApiController]
+[Route("api/[controller]")]
 public class DepartmentsController : ControllerBase
 {
     private readonly IDepartmentService _service;

--- a/TicketingSystem.API/Controllers/NotificationQueuesController.cs
+++ b/TicketingSystem.API/Controllers/NotificationQueuesController.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc; // <-- Add this using directive
+using Microsoft.AspNetCore.Mvc;
 
+[ApiController]
+[Route("api/[controller]")]
 public class NotificationQueuesController : ControllerBase
 {
     private readonly INotificationQueueService _service;

--- a/TicketingSystem.API/Controllers/NotificationRulesController.cs
+++ b/TicketingSystem.API/Controllers/NotificationRulesController.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc; // <-- Add this using directive
+using Microsoft.AspNetCore.Mvc;
 
+[ApiController]
+[Route("api/[controller]")]
 public class NotificationRulesController : ControllerBase
 {
     private readonly INotificationRuleService _service;

--- a/TicketingSystem.API/Controllers/OrganizationsController.cs
+++ b/TicketingSystem.API/Controllers/OrganizationsController.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc; // <-- Add this using directive
+using Microsoft.AspNetCore.Mvc;
 
+[ApiController]
+[Route("api/[controller]")]
 public class OrganizationsController : ControllerBase
 {
     private readonly IOrganizationService _service;

--- a/TicketingSystem.API/Controllers/ProjectsController.cs
+++ b/TicketingSystem.API/Controllers/ProjectsController.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
 
+[ApiController]
+[Route("api/[controller]")]
 public class ProjectsController : ControllerBase
 {
     private readonly IProjectService _projectService;

--- a/TicketingSystem.API/Controllers/ReportsController.cs
+++ b/TicketingSystem.API/Controllers/ReportsController.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
 
+[ApiController]
+[Route("api/[controller]")]
 public class ReportsController : ControllerBase
 {
     private readonly IReportService _reportService;

--- a/TicketingSystem.API/Controllers/SlaPoliciesController.cs
+++ b/TicketingSystem.API/Controllers/SlaPoliciesController.cs
@@ -1,5 +1,8 @@
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc; // <-- Add this using directive
+using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+[Route("api/[controller]")]
 public class SlaPoliciesController : ControllerBase
 {
     private readonly ISlaPolicyService _service;

--- a/TicketingSystem.API/Controllers/TeamAssignmentsController.cs
+++ b/TicketingSystem.API/Controllers/TeamAssignmentsController.cs
@@ -1,5 +1,8 @@
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc; // <-- Add this using directive
+using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+[Route("api/[controller]")]
 public class TeamAssignmentsController : ControllerBase
 {
     private readonly ITeamAssignmentService _service;

--- a/TicketingSystem.API/Controllers/TicketAttachmentsController.cs
+++ b/TicketingSystem.API/Controllers/TicketAttachmentsController.cs
@@ -1,5 +1,8 @@
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc; 
+using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+[Route("api/[controller]")]
 public class TicketAttachmentsController : ControllerBase
 {
     private readonly ITicketAttachmentService _service;

--- a/TicketingSystem.API/Controllers/TicketCommentsController.cs
+++ b/TicketingSystem.API/Controllers/TicketCommentsController.cs
@@ -2,6 +2,8 @@ using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
+[ApiController]
+[Route("api/[controller]")]
 public class TicketCommentsController : ControllerBase
 {
     private readonly ITicketCommentService _commentService;

--- a/TicketingSystem.API/Controllers/TicketHistoriesController.cs
+++ b/TicketingSystem.API/Controllers/TicketHistoriesController.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
+[ApiController]
+[Route("api/[controller]")]
 public class TicketHistoriesController : ControllerBase
 {
     private readonly ITicketHistoryService _service;

--- a/TicketingSystem.API/Controllers/TimeEntriesController.cs
+++ b/TicketingSystem.API/Controllers/TimeEntriesController.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
+[ApiController]
+[Route("api/[controller]")]
 public class TimeEntriesController : ControllerBase
 {
     private readonly ITimeEntryService _service;

--- a/TicketingSystem.API/Controllers/UserSessionsController.cs
+++ b/TicketingSystem.API/Controllers/UserSessionsController.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
+[ApiController]
+[Route("api/[controller]")]
 public class UserSessionsController : ControllerBase
 {
     private readonly IUserSessionService _service;

--- a/TicketingSystem.API/Controllers/UserSkillsController.cs
+++ b/TicketingSystem.API/Controllers/UserSkillsController.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
+[ApiController]
+[Route("api/[controller]")]
 public class UserSkillsController : ControllerBase
 {
     private readonly IUserSkillService _service;

--- a/TicketingSystem.API/Controllers/UsersController.cs
+++ b/TicketingSystem.API/Controllers/UsersController.cs
@@ -2,6 +2,8 @@ using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
 
+[ApiController]
+[Route("api/[controller]")]
 public class UsersController : ControllerBase
 {
     private readonly IUserService _userService;


### PR DESCRIPTION
## Summary
- add `[ApiController]` and `Route("api/[controller]")` to remaining controllers
- ensure `Microsoft.AspNetCore.Mvc` and `Microsoft.AspNetCore.Authorization` usings are present

## Testing
- `dotnet test` *(fails: type or namespace name 'Models' does not exist in the namespace 'Microsoft.OpenApi')*

------
https://chatgpt.com/codex/tasks/task_b_688f24d8fc78832581f32f7a51ab3585