### PR TITLE
Add tickets controller with CRUD endpoints

### DIFF
--- a/TicketingSystem.API/Controllers/TicketsController.cs
+++ b/TicketingSystem.API/Controllers/TicketsController.cs
@@ -1,0 +1,104 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace TicketingSystem.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class TicketsController : ControllerBase
+    {
+        private readonly ITicketService _ticketService;
+        private readonly ILogger<TicketsController> _logger;
+
+        public TicketsController(ITicketService ticketService, ILogger<TicketsController> logger)
+        {
+            _ticketService = ticketService;
+            _logger = logger;
+        }
+
+        [HttpGet]
+        [Authorize]
+        public async Task<IActionResult> GetAll()
+        {
+            try
+            {
+                var tickets = await _ticketService.GetAllAsync(User);
+                return Ok(tickets);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error in TicketsController");
+                return StatusCode(500, "Internal server error.");
+            }
+        }
+
+        [HttpGet("{id}")]
+        [Authorize]
+        public async Task<IActionResult> GetById(int id)
+        {
+            try
+            {
+                var ticket = await _ticketService.GetByIdAsync(id, User);
+                if (ticket == null) return NotFound();
+                return Ok(ticket);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error in TicketsController");
+                return StatusCode(500, "Internal server error.");
+            }
+        }
+
+        [HttpPost]
+        [Authorize]
+        public async Task<IActionResult> Create([FromBody] TicketCreateDto dto)
+        {
+            try
+            {
+                if (!ModelState.IsValid) return BadRequest(ModelState);
+                var created = await _ticketService.CreateAsync(dto, User);
+                return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error in TicketsController");
+                return StatusCode(500, "Internal server error.");
+            }
+        }
+
+        [HttpPut("{id}")]
+        [Authorize]
+        public async Task<IActionResult> Update(int id, [FromBody] TicketUpdateDto dto)
+        {
+            try
+            {
+                if (!ModelState.IsValid) return BadRequest(ModelState);
+                var updated = await _ticketService.UpdateAsync(id, dto, User);
+                if (updated == null) return NotFound();
+                return Ok(updated);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error in TicketsController");
+                return StatusCode(500, "Internal server error.");
+            }
+        }
+
+        [HttpDelete("{id}")]
+        [Authorize(Roles = "Admin")]
+        public async Task<IActionResult> Delete(int id)
+        {
+            try
+            {
+                var deleted = await _ticketService.DeleteAsync(id, User);
+                if (!deleted) return NotFound();
+                return NoContent();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error in TicketsController");
+                return StatusCode(500, "Internal server error.");
+            }
+        }
+    }
+}

--- a/TicketingSystem.API/Models/DTOs/TicketUpdateDto.cs
+++ b/TicketingSystem.API/Models/DTOs/TicketUpdateDto.cs
@@ -1,0 +1,15 @@
+using System;
+
+public class TicketUpdateDto
+{
+    public string Title { get; set; }
+    public string Description { get; set; }
+    public string Category { get; set; }
+    public string Subcategory { get; set; }
+    public string Priority { get; set; }
+    public string Impact { get; set; }
+    public string Urgency { get; set; }
+    public DateTime? DueDate { get; set; }
+    public string SLA { get; set; }
+    public string Status { get; set; }
+}

--- a/TicketingSystem.API/Program.cs
+++ b/TicketingSystem.API/Program.cs
@@ -45,6 +45,7 @@ builder.Services.AddScoped<IReportService, ReportService>();
 builder.Services.AddScoped<IAttachmentService, AttachmentService>();
 builder.Services.AddScoped<ITicketCommentService, TicketCommentService>();
 builder.Services.AddScoped<INotificationService, NotificationService>();
+builder.Services.AddScoped<ITicketService, TicketService>();
 
 var app = builder.Build();
 

--- a/TicketingSystem.API/Services/ITicketService.cs
+++ b/TicketingSystem.API/Services/ITicketService.cs
@@ -5,6 +5,8 @@ public interface ITicketService
     Task<IEnumerable<TicketDto>> GetAllAsync(ClaimsPrincipal user);
     Task<TicketDto> GetByIdAsync(int id, ClaimsPrincipal user);
     Task<TicketDto> CreateAsync(TicketCreateDto dto, ClaimsPrincipal user);
-   
+    Task<TicketDto> UpdateAsync(int id, TicketUpdateDto dto, ClaimsPrincipal user);
+    Task<bool> DeleteAsync(int id, ClaimsPrincipal user);
+
     Task<bool> AssignToAgentAsync(int ticketId, int agentId);
 }

--- a/TicketingSystem.API/Services/TicketService.cs
+++ b/TicketingSystem.API/Services/TicketService.cs
@@ -123,6 +123,64 @@ public class TicketService : ITicketService
         }
     }
 
+    public async Task<TicketDto> UpdateAsync(int id, TicketUpdateDto dto, ClaimsPrincipal user)
+    {
+        try
+        {
+            var ticket = await _context.Tickets.FindAsync(id);
+            if (ticket == null)
+                throw new KeyNotFoundException($"Ticket with ID {id} not found.");
+
+            ticket.Title = dto.Title;
+            ticket.Description = dto.Description;
+            ticket.Category = dto.Category;
+            ticket.Subcategory = dto.Subcategory;
+            ticket.Priority = dto.Priority;
+            ticket.Impact = dto.Impact;
+            ticket.Urgency = dto.Urgency;
+            ticket.DueDate = dto.DueDate;
+            ticket.SLA = dto.SLA;
+            ticket.Status = dto.Status;
+            ticket.UpdatedAt = DateTime.UtcNow;
+
+            await _context.SaveChangesAsync();
+
+            return new TicketDto
+            {
+                Id = ticket.Id,
+                TicketNumber = ticket.TicketNumber,
+                Title = ticket.Title,
+                Priority = ticket.Priority,
+                Status = ticket.Status,
+                CreatedAt = ticket.CreatedAt
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error in UpdateAsync");
+            throw;
+        }
+    }
+
+    public async Task<bool> DeleteAsync(int id, ClaimsPrincipal user)
+    {
+        try
+        {
+            var ticket = await _context.Tickets.FindAsync(id);
+            if (ticket == null) return false;
+
+            _context.Tickets.Remove(ticket);
+            await _context.SaveChangesAsync();
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error in DeleteAsync");
+            throw;
+        }
+    }
+
     public async Task<bool> AssignToAgentAsync(int ticketId, int agentId)
     {
         try


### PR DESCRIPTION
## Summary
- add TicketsController with CRUD endpoints backed by ITicketService
- extend ticket service and interface for update and delete, plus TicketUpdateDto
- register TicketService for dependency injection

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_b_688f24ddf5608325a174be23be3646a3