### PR TITLE
Add request DTO using to auth service

### DIFF
--- a/TicketingSystem.API/Services/AuthService.cs
+++ b/TicketingSystem.API/Services/AuthService.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using System.Security.Claims;
 using System.Text;
 using Microsoft.IdentityModel.Tokens;
+using TicketingSystem.API.Requests;
 // using TicketingSystem.API.DTOs; // Example, adjust as needed
 
 public class AuthService : IAuthService


### PR DESCRIPTION
## Summary
- ensure AuthService references request DTOs via TicketingSystem.API.Requests
- verify AuthService method signatures match IAuthService

## Testing
- `dotnet test`
- `dotnet build` *(fails: CS1513 `}` expected in RegisterRequest.cs, LoginRequest.cs)*

------
https://chatgpt.com/codex/tasks/task_b_688f4dab92e08325927e6713f241929c