### PR TITLE
Add validation attributes to RegisterRequest

### DIFF
--- a/TicketingSystem.API/Requests/RegisterRequest.cs
+++ b/TicketingSystem.API/Requests/RegisterRequest.cs
@@ -1,10 +1,19 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 
-namespace TicketingSystem.API.Requests; 
+namespace TicketingSystem.API.Requests;
+
 public class RegisterRequest
 {
+    [Required]
     public string OrgName { get; set; }
+
+    [Required, EmailAddress]
     public string Email { get; set; }
+
+    [Required]
     public string Password { get; set; }
+
+    [Required]
     public string FullName { get; set; }
+}


### PR DESCRIPTION
## Summary
- add validation annotations to register request properties
- close RegisterRequest class definition properly

## Testing
- `dotnet test TicketingSystem.API.Tests` *(fails: `LoginRequest.cs(9,41): error CS1513: } expected`)*

------
https://chatgpt.com/codex/tasks/task_b_688f4dae961083258b9c3d33298d6dc7